### PR TITLE
Adjust checkbox label spacing

### DIFF
--- a/solr/webapp/web/css/angular/schema-designer.css
+++ b/solr/webapp/web/css/angular/schema-designer.css
@@ -733,9 +733,9 @@ limitations under the License.
 }
 
 #content #designer .schema-actions label.checkbox {
-  margin-left: 27%;
+  margin-left: 0;
   text-align: left;
-  width: 73%;
+  width: 100%;
   padding: 0px;
   margin-top: 0px;
 }

--- a/solr/webapp/web/css/angular/schema.css
+++ b/solr/webapp/web/css/angular/schema.css
@@ -633,9 +633,9 @@ limitations under the License.
 }
 
 #content #schema .actions label.checkbox {
-  margin-left: 27%;
+  margin-left: 0;
   text-align: left;
-  width: 73%;
+  width: 100%;
   padding: 0px;
   margin-top: 0px;
 }


### PR DESCRIPTION
## Summary
- shrink the left margin for checkbox labels to reduce the gap between the tick box and its text

## Testing
- `./gradlew tidy updateLicenses check -x test` *(fails: Could not download gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc580804832c8c68c434efcd206f